### PR TITLE
Add committer team as security manager

### DIFF
--- a/otterdog/eclipse-jdt.jsonnet
+++ b/otterdog/eclipse-jdt.jsonnet
@@ -14,6 +14,9 @@ orgs.newOrg('eclipse-jdt') {
     packages_containers_internal: false,
     packages_containers_public: false,
     readers_can_create_discussions: true,
+    security_managers+: [
+      "eclipse-jdt-committers"
+    ],
     two_factor_requirement: false,
     web_commit_signoff_required: false,
   },


### PR DESCRIPTION
As requested in confidential ticket by @jukzi .

Requiring approval from project leads (team is not public, thus can not add it as reviewer).