### PR TITLE
Add JDT_BOT_PAT to 'eclipse.jdt' repository

### DIFF
--- a/otterdog/eclipse-jdt.jsonnet
+++ b/otterdog/eclipse-jdt.jsonnet
@@ -49,6 +49,11 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
           requires_strict_status_checks: true,
         },
       ],
+      secrets: [
+        orgs.newRepoSecret('JDT_BOT_PAT') {
+          value: "pass:bots/eclipse.jdt/github.com/token-hd5020",
+        },
+      ],
     },
     orgs.newRepo('eclipse.jdt.core') {
       allow_merge_commit: false,


### PR DESCRIPTION
Relates to
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5020#note_2825965

As mentioned in
- https://github.com/eclipse-jdt/eclipse.jdt/pull/123#discussion_r2068166010

this is required for
- https://github.com/eclipse-jdt/eclipse.jdt/pull/136

@jarthana or @mpalat please approve this as JDT-PL.

