### PR TITLE
Enable automated deletion of branches for all active repositories

### DIFF
--- a/otterdog/eclipse-jdt.jsonnet
+++ b/otterdog/eclipse-jdt.jsonnet
@@ -21,7 +21,7 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
   ],
   _repositories+:: [
     orgs.newRepo('.github') {
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
@@ -30,7 +30,7 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
     },
     orgs.newRepo('eclipse.jdt') {
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_projects: false,
       has_wiki: false,
       web_commit_signoff_required: false,
@@ -58,7 +58,7 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
     orgs.newRepo('eclipse.jdt.core') {
       allow_merge_commit: false,
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_discussions: true,
       has_projects: false,
       web_commit_signoff_required: false,
@@ -85,7 +85,7 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
     },
     orgs.newRepo('eclipse.jdt.core.binaries') {
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_projects: false,
       has_wiki: false,
       web_commit_signoff_required: false,
@@ -107,7 +107,7 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
     },
     orgs.newRepo('eclipse.jdt.debug') {
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_discussions: true,
       has_projects: false,
       has_wiki: false,
@@ -136,7 +136,7 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
     orgs.newRepo('eclipse.jdt.ui') {
       allow_merge_commit: false,
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       has_projects: false,
       has_wiki: false,
       web_commit_signoff_required: false,
@@ -165,7 +165,7 @@ orgs.newOrg('eclipse.jdt', 'eclipse-jdt') {
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",
-      delete_branch_on_merge: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {
         enabled: false,


### PR DESCRIPTION
## What it does

This makes it simpler to keep the repositories clean of unused branches (e.g. created by bots).

Similar to https://github.com/eclipse-platform/.eclipsefdn/pull/18

@jarthana, @mpalat please review and approve this change if you are fine with it.


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
